### PR TITLE
Add actual DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,6 @@ authors:
   given-names: Alison
 title: "wildwing"
 version: 1.0.0
-doi: 10.5281/zenodo.1234
+doi: 10.5281/zenodo.14902302
 date-released: 2025-02-20
 url: "https://github.com/Imageomics/wildwing"


### PR DESCRIPTION
This seemed to have a placeholder, so fixes the citation to point to the actual DOI.